### PR TITLE
update installation guide to latest , example: 1.1.0

### DIFF
--- a/_includes/guides.html
+++ b/_includes/guides.html
@@ -22,7 +22,7 @@
                         <a href="https://rackhd.readthedocs.io/en/latest/tutorials/index.html" class="list-group-item list-group-item-fixed-border">
                              <h5 class="grid_content grid_content_dark">Tutorials</h5>
                         </a>
-                        <a href="https://rackhd.atlassian.net/wiki/display/RAC1/RackHD+Installation+Guide+-1.0.0" class="list-group-item list-group-item-fixed-border">
+                        <a href="https://rackhd.atlassian.net/wiki/display/RAC1/RackHD+Release+Installation+Guide" class="list-group-item list-group-item-fixed-border">
                              <h5 class="grid_content grid_content_dark">Installation</h5>
                         </a>
                         <a href="https://rackhd.atlassian.net/wiki/pages/viewpage.action?pageId=20024337#GettingStartedwithRackHD™-Support:Packagereleases,CreateRackHDBugs,andFeatureRequests" class="list-group-item list-group-item-fixed-border">

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -13,7 +13,7 @@
             </div>
             <div class="col-lg-8 col-lg-offset-2 text-center">
                  <div class="btn-toolbar">
-                    <a href="https://rackhd.atlassian.net/wiki/display/RAC1/RackHD+Installation+Guide+-1.0.0" class="btn btn-sm btn-outline">
+                    <a href="https://rackhd.atlassian.net/wiki/display/RAC1/RackHD+Release+Installation+Guide" class="btn btn-sm btn-outline">
                          <i class="fa fa-download"></i>Get RackHD
                     </a>
                     <a href="https://github.com/RackHD" class="btn btn-sm btn-outline">

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -13,7 +13,7 @@
             </div>
             <div class="col-lg-8 col-lg-offset-2 text-center">
                  <div class="btn-toolbar">
-                    <a href="https://rackhd.atlassian.net/wiki/display/RAC1/RackHD+Release+Installation+Guide" class="btn btn-sm btn-outline">
+                    <a href="https://rackhd.atlassian.net/wiki/display/RAC1/RackHD+Release+Page" class="btn btn-sm btn-outline">
                          <i class="fa fa-download"></i>Get RackHD
                     </a>
                     <a href="https://github.com/RackHD" class="btn btn-sm btn-outline">


### PR DESCRIPTION
actually, the new page is version agnostic. "https://rackhd.atlassian.net/wiki/display/RAC1/RackHD+Release+Installation+Guide"