### PR TITLE
change to contributing link

### DIFF
--- a/_includes/guides.html
+++ b/_includes/guides.html
@@ -48,7 +48,7 @@
                         <a href="http://rackhd.readthedocs.io/en/latest/devguide/repositories.html" class="list-group-item list-group-item-fixed-border">
                              <h5 class="grid_content grid_content_dark">Repositories Overview</h5>
                         </a>
-                        <a href="http://rackhd.readthedocs.io/en/latest/devguide/contributing.html" class="list-group-item list-group-item-fixed-border">
+                        <a href="http://rackhd.readthedocs.io/en/latest/contributing.html" class="list-group-item list-group-item-fixed-border">
                              <h5 class="grid_content grid_content_dark">How To Contribute</h5>
                         </a>
                         <a href="http://rackhd.readthedocs.io/en/latest/devguide/debugging_guide.html" class="list-group-item list-group-item-fixed-border">


### PR DESCRIPTION
thanks to  @pscharla , he pointed out:

>  Section 4.2.1 of readthedocs, core committer list is way outdated:
> http://rackhd.readthedocs.io/en/latest/contributing.html?highlight=core%20committer
> I also notice section 4.1 refers to google groups, so should change that too if we're transitioning to confluence


@yyscamper  @anhou   @leoyjchang 