### PR TITLE
Update link to RackHD Twitter URL under page footer

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -42,7 +42,7 @@ footer:
 # Social networks usernames (many more available: google-plus, flickr, dribbble, pinterest, instagram, tumblr, linkedin, etc.)
 social:
   - title: twitter
-    url: https://twitter.com/rack_hd 
+    url: https://twitter.com/rackhd 
   - title: group
     url: https://groups.google.com/forum/#!forum/rackhd 
   - title: github


### PR DESCRIPTION
**Background**

The link of RackHD twitter URL on main page footer pointed to "https://twitter.com/rack_hd" which is not reachable. It should be updated to "https://twitter.com/rackhd".

@panpan0000 @pengz1 @changev @anhou 
