### PR TITLE
RAC-6612: Clean up rackhd.github.io web portal

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -48,7 +48,7 @@ social:
   - title: github
     url: https://github.com/RackHD 
   - title: slack
-    url: https://codecommunity.slack.com/archives/rackhd 
+    url: https://rackhd.slack.com
 
 # Postal address (add as many lines as necessary)
 #address:

--- a/_includes/feature_grid.html
+++ b/_includes/feature_grid.html
@@ -96,7 +96,7 @@
                         <p><img  src="img/features/icons8.com-Like It-100.png" width="50" height="50" alt=""></p>
                     </div>
                     <h4 class="grid_title"> You define RackHD </h4>
-                    <h6 class="grid_content"><p> Contribute your ideas for new and revised features, refer to <a href="https://rackhd.atlassian.net/wiki/pages/viewpage.action?pageId=20024337#GettingStartedwithRackHD™-Support:Packagereleases,CreateRackHDBugs,andFeatureRequests">link</a> for more.. </p><h6>
+                    <h6 class="grid_content"><p> Contribute your ideas for new and revised features, refer to <a href="https://rackhd.atlassian.net/wiki/pages/viewpage.action?pageId=20024337#GettingStartedwithRackHD-Support:Packagereleases,CreateRackHDBugs,andFeatureRequests">link</a> for more.. </p><h6>
                 </div>
                 <div class="col-sm-3 feature_grid">
                     <div align="center">

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -6,10 +6,10 @@
                     <div class="footer-col col-md-3 col-md-offset-1">
                         <h5 style="text-align: left;">Documents</h5>
                         <h6 class="grid_content"> <li class="big_margin">
-                            <a style="color:gray" href="https://rackhd.readthedocs.io/en/latest/tutorials/index.html"> Tutorial </a>
+                            <a style="color:gray" href="http://rackhd.readthedocs.io/en/latest/quick_guide.html"> Tutorial </a>
                         </li> </h6>
                         <h6 class="grid_content"> <li class="big_margin">
-                            <a style="color:gray" href="https://rackhd.readthedocs.io/en/latest/introduction.html"> RackHD Overview  </a>
+                            <a style="color:gray" href="http://rackhd.readthedocs.io/en/latest/rackhd_overview.html"> RackHD Overview  </a>
                         </li> </h6>
                         <h6 class="grid_content"> <li class="big_margin">
                             <a style="color:gray" href="http://rackhd.readthedocs.io/en/latest/" >RackHD Documentation  </a>

--- a/_includes/guides.html
+++ b/_includes/guides.html
@@ -12,30 +12,33 @@
                     <img class="img-responsive"  src="img/icons8.com-User.png" alt="">
                 </div>
                 <div class="col-lg-3" style="margin-top: -15px">
-                    <a href="https://rackhd.readthedocs.io/en/latest/rackhd/index.html">
+                    <a href="https://rackhd.readthedocs.io">
                         <h4 style="margin:0px 20px;">RackHD User Guide<br><br></h4>
                     </a>
                     <div class="list-group" style=" margin:0 auto;">
-                        <a href="http://rackhd.readthedocs.io/en/latest/introduction.html" class="list-group-item list-group-item-fixed-border">
+                        <a href="http://rackhd.readthedocs.io/en/latest/rackhd_overview.html" class="list-group-item list-group-item-fixed-border">
                              <h5 class="grid_content grid_content_dark">Overview</h5>
                         </a>
-                        <a href="https://rackhd.readthedocs.io/en/latest/tutorials/index.html" class="list-group-item list-group-item-fixed-border">
+                        <a href=" http://rackhd.readthedocs.io/en/latest/quick_guide.html" class="list-group-item list-group-item-fixed-border">
                              <h5 class="grid_content grid_content_dark">Tutorials</h5>
                         </a>
                         <a href="https://rackhd.atlassian.net/wiki/display/RAC1/RackHD+Release+Installation+Guide" class="list-group-item list-group-item-fixed-border">
                              <h5 class="grid_content grid_content_dark">Installation</h5>
                         </a>
-                        <a href="https://rackhd.atlassian.net/wiki/pages/viewpage.action?pageId=20024337#GettingStartedwithRackHD™-Support:Packagereleases,CreateRackHDBugs,andFeatureRequests" class="list-group-item list-group-item-fixed-border">
+                        <a href="http://rackhd.readthedocs.io/latest/2.0/rackhd_vlab/index.html" class="list-group-item list-group-item-fixed-border">
+                             <h5 class="grid_content grid_content_dark">RackHD Hands-on vLab</h5>
+                        </a>
+                        <a href="https://rackhd.atlassian.net/wiki/spaces/RAC1/pages/20024337/Getting+Started+with+RackHD#GettingStartedwithRackHD-Support:Installation,CreateBugs,andFeatureRequests" class="list-group-item list-group-item-fixed-border">
                              <h5 class="grid_content grid_content_dark">Request Demands</h5>
                         </a>
-                        <a href="https://rackhd.atlassian.net/wiki/pages/viewpage.action?pageId=20024337#GettingStartedwithRackHD™-Support:Packagereleases,CreateRackHDBugs,andFeatureRequests" class="list-group-item list-group-item-fixed-border">
+                        <a href="https://rackhd.atlassian.net//secure/CreateIssueDetails!init.jspa?pid=10001&issuetype=10003" class="list-group-item list-group-item-fixed-border">
                              <h5 class="grid_content grid_content_dark">Report Bug/Vulnerability</h5>
                         </a>
                         <a href="https://rackhd.atlassian.net/wiki/display/RAC1/RackHD+Release+Page" class="list-group-item list-group-item-fixed-border">
                              <h5 class="grid_content grid_content_dark">Releases</h5>
                         </a>
-                        <a href="https://rackhd.atlassian.net/wiki/display/RAC1/RackHD+Hardware+Compatibility+List" class="list-group-item list-group-item-fixed-border">
-                             <h5 class="grid_content grid_content_dark">Hardware Compatibility List</h5>
+                        <a href="http://rackhd.readthedocs.io/en/latest/support_matrix.html" class="list-group-item list-group-item-fixed-border">
+                             <h5 class="grid_content grid_content_dark">RackHD Support Matrix</h5>
                         </a>						
                     </div>
                 </div>
@@ -48,24 +51,25 @@
                         <h4 style="margin:0px 20px;">RackHD Development Guide<br><br></h4>
                     </a>
                     <div class="list-group" style=" margin:0 auto;">
-                        <a href="http://rackhd.readthedocs.io/en/latest/devguide/repositories.html" class="list-group-item list-group-item-fixed-border">
+                        <a href="http://rackhd.readthedocs.io/en/latest/dev_guide/repositories.html" class="list-group-item list-group-item-fixed-border">
                              <h5 class="grid_content grid_content_dark">Repositories Overview</h5>
                         </a>
                         <a href="http://rackhd.readthedocs.io/en/latest/contributing.html" class="list-group-item list-group-item-fixed-border">
                              <h5 class="grid_content grid_content_dark">How To Contribute</h5>
                         </a>
-                        <a href="http://rackhd.readthedocs.io/en/latest/devguide/debugging_guide.html" class="list-group-item list-group-item-fixed-border">
+                        <a href="http://rackhd.readthedocs.io/en/latest/dev_guide/debugging_guide.html" class="list-group-item list-group-item-fixed-border">
                              <h5 class="grid_content grid_content_dark">How To Debug</h5>
                         </a>
-                        <a href="https://rackhd.atlassian.net/wiki/pages/viewpage.action?pageId=20024337#GettingStartedwithRackHD-Licensing" class="list-group-item list-group-item-fixed-border">
+                        <a href="https://rackhd.atlassian.net/wiki/pages/viewpage.action?pageId=20024337#GettingStartedwithRackHD-Licensing" class="list-group-item list-group-item-fixed-border">
                              <h5 class="grid_content grid_content_dark">License</h5>
                         </a>
-                        <a href="#" class="list-group-item list-group-item-fixed-border">
+                        <a href="http://rackhd.readthedocs.io/en/latest/run_rackhd/security.html" class="list-group-item list-group-item-fixed-border">
                              <h5 class="grid_content grid_content_dark">Product Security Guide</h5>
                         </a>
+                        <!--
                         <a href="http://147.178.202.18/" class="list-group-item list-group-item-fixed-border">
                              <h5 class="grid_content grid_content_dark">Jenkins</h5>
-                        </a>
+                        </a>-->
                     </div>
                 </div>
             </div>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -19,12 +19,12 @@
                     <a href="https://github.com/RackHD" class="btn btn-sm btn-outline">
                          <i class="fa fa-github"></i> GitHub <span class="badge">Apache 2.0</span>
                     </a>
-                    <a href="https://rackhd.readthedocs.io/en/latest/tutorials/index.html" class="btn btn-sm btn-outline">
+                    <a href="http://rackhd.readthedocs.io/en/latest/quick_guide.html" class="btn btn-sm btn-outline">
                          <i class="fa fa-try"></i> Tutorial
                     </a>
             </div>
             <div class="col-lg-10 col-lg-offset-1 style">
-                    <a href="https://codecommunity.slack.com/archives/rackhd" class="btn btn-sm btn-outline">
+                    <a href="https://rackhd.slack.com" class="btn btn-sm btn-outline">
                          <i class="fa fa-slack"></i> Slack
                     </a>
                     <a href="https://rackhd.atlassian.net/wiki/spaces/kbr/overview" class="btn btn-sm btn-outline">

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -42,15 +42,17 @@
                      <li class="page-scroll">
                         <a href="#footer">More</a>
                     </li>
+                    <!--
                     <li>
                         <a id="adbar-bookmark" class="adbar-bookmark" style="display: none;">
                             Survey <i class="fa fa-question-circle" aria-hidden="true"></i>
                         </a>
-                    </li>
+                    </li>-->
                 </ul>
             </div>
             <!-- /.navbar-collapse -->
         </div>
+        <!--
         <div class="collapse collapse-ad-bar in" id="collapseAdBar">
             <div class="container">
                 <div class="row  text-center">
@@ -62,6 +64,6 @@
                     </div>
                 </div>
             </div>
-        </div>
+        </div> -->
         <!-- /.container-fluid -->
     </nav>

--- a/_includes/news.html
+++ b/_includes/news.html
@@ -15,10 +15,13 @@
                         
                         <h3 style="  border-bottom: 2px solid; color:DeepSkyBlue; width:100%;"> 
                             NEWS 
-                            <a href="https://rackhd.atlassian.net/wiki/display/RAC1/Upcoming+Events" style="float:right;color: #03a9f4"><h5>Learn More...  <i class="fa fa-angle-double-right" aria-hidden="true"></i></h5></a>
+                            <!--<a href="https://rackhd.atlassian.net/wiki/display/RAC1/Upcoming+Events" style="float:right;color: #03a9f4"><h5>Learn More...  <i class="fa fa-angle-double-right" aria-hidden="true"></i></h5></a>-->
                         </h3>
                         {% assign flag = "ture" %}	
                         {% for post in site.posts %}
+                            {% capture postDate %}{{post.date | date: '%Y %m %-d' }}{% endcapture %}
+                            {% capture latestDate%}{{'2017-08-01' | date: '%Y %m %-d'}}{% endcapture%}
+                            {% if postDate >= latestDate %}
                             <a href="#portfolioModal-{{ post.modal-id }}" data-toggle="modal" class="list-group-item list-group-item-fixed-border">
                             <img src="img/news/{{post.icon}}" style="margin-right:13px;margin-left: 2px; height:30px; width:30px;float: left;">
                             <p>{{ post.title }}</p>
@@ -26,6 +29,7 @@
                                <img src="img/news/icons8.com-High-Importance-26.png" style="margin-right:2px;margin-left:5px;margin-top:-30px; height:30px; width:30px;float: right;">                           							
                             {% endif %}
                             </a>
+                            {% endif %}
                         {% assign flag = "false" %}
                         {% endfor %}
                         <a href="https://rackhd.atlassian.net/wiki/display/RAC1/RackHD+Release+Page" class="list-group-item list-group-item-fixed-border">
@@ -48,14 +52,14 @@
                     <p>Dell EMC Teams Backlogs</p>
                     </a>
 
-                    <a href="https://rackhd.atlassian.net/wiki/pages/viewpage.action?pageId=19824661" class="list-group-item list-group-item-fixed-border">
+                    <a href="http://rackhd.readthedocs.io/en/latest/customer_support/frequent_asks.html" class="list-group-item list-group-item-fixed-border">
                     <img src="img/news/icons8.com-Route-60.png" style="margin-right:10px; height:40px; width:40px;float: left">
-                    <p>RackHD Roadmap</p>
+                    <p>Frequent Asks</p>
                     </a>
 
-                    <a href="https://rackhd.atlassian.net/wiki/display/RAC1/Core+Commiter+Weekly+Interlock" class="list-group-item list-group-item-fixed-border">
+                    <a href="http://rackhd.readthedocs.io/en/latest/customer_support/howto_index.html" class="list-group-item list-group-item-fixed-border">
                     <img src="img/news/icons8.com-Handshake-60.png" style="margin-right:10px; height:40px; width:40px;float: left">
-                    <p>Core Committee Minutes</p>
+                    <p>How To</p>
                     </a>
                 </div>
                 <div class="col-lg-6">

--- a/_posts/2017-10-27-move-to-concourse.markdown
+++ b/_posts/2017-10-27-move-to-concourse.markdown
@@ -1,0 +1,14 @@
+---
+layout: default
+title: Move to Concourse 
+modal-id: 4
+date: 2017-10-27
+img: 
+icon: icons8.com-Remove-Property-64.png 
+alt: 
+project-date:  2017 Oct
+#client: Start Bootstrap
+#category: Web Development
+description: Since 2017 Oct.27, RackHD switches over to Concourse based pipelines for pull request quality gate testing and continous delivery. When a PR is created, a RackHD committer will first need to set the run-test label on the PR to allow the PR quality gate test runs. A RackHD committer will then need to review the PR. Once the PR code reviews and PR gate test pass, a RackHD committer can merge the PR to master. Once the PR has been merged to master, the "Post Merge Test" will run. Once the "Post Merge Test" passes, the new docker, debian image will be posted to Dockerhub and bintray. A link to the PR status will be posted to the PR status in github with details and log information. "http://rackhd.readthedocs.io/en/latest/devguide/contributing.html#quality-gates-for-the-pull-requests" is  updated to reflect these changes. At the same time, OVA/Vagrant packages release have be deprecated, but scripts are provided to help community to build images.
+
+---

--- a/_posts/2018-04-25-move-to-new-slack.markdown
+++ b/_posts/2018-04-25-move-to-new-slack.markdown
@@ -1,0 +1,14 @@
+---
+layout: default
+title: Move to New Slack 
+modal-id: 2 
+date: 2018-04-25
+img: 
+icon: dellemc.jpg 
+alt: 
+project-date:  2018 April
+#client: Start Bootstrap
+#category: Web Development
+description: RackHD project will be moving to its own Slack workspace(rackhd.slack.com ) starting May 1st 2018. To make sure you don’t miss out on any communications, please make sure you’re signed up for the new RackHD Slack as soon as possible.<br/> We have made the signup very simple, just head over to <a href="https://slackinviterrackhd.herokuapp.com/"></a> and you’ll get an invite in your inbox shortly. As the same time, the original Slack channel (<a href="https://codecommunity.slack.com/archives/rackhd"></a>) will be deprecated.
+
+---


### PR DESCRIPTION
**Backgroud**
A lot of information in rackhd.github.io web portal are out of date. We need to update it.
you can go to "https://yaolingling.github.io" for the latest web.


**Reviewers:**
@panpan0000 @iceiilin  @anhou 