### PR TITLE
Update link to slack with sign-up URL

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -48,7 +48,7 @@ social:
   - title: github
     url: https://github.com/RackHD 
   - title: slack
-    url: https://rackhd.slack.com
+    url: https://slackinviterrackhd.herokuapp.com/
 
 # Postal address (add as many lines as necessary)
 #address:

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -24,7 +24,7 @@
                     </a>
             </div>
             <div class="col-lg-10 col-lg-offset-1 style">
-                    <a href="https://rackhd.slack.com" class="btn btn-sm btn-outline">
+                    <a href="https://slackinviterrackhd.herokuapp.com" class="btn btn-sm btn-outline">
                          <i class="fa fa-slack"></i> Slack
                     </a>
                     <a href="https://rackhd.atlassian.net/wiki/spaces/kbr/overview" class="btn btn-sm btn-outline">


### PR DESCRIPTION
#Background
Today the RackHD.io link points directly to the RackHD Slack channel. Since Slack is basically a closed system, new users need to be pointed to the registration landing page that was created. 

@yaolingling @panpan0000 @lanchongyizu @iceiilin 
